### PR TITLE
Use InfluxDBClient.write_api(SYNCHRONOUS) so file handles are closed

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -28,9 +28,7 @@ allow_untyped_defs = True
 allow_untyped_calls = True
 
 # There is no type hinting for influxdb_client
-[mypy-influxdb_client]
-ignore_missing_imports = True
-[mypy-influxdb_client.client.exceptions]
+[mypy-influxdb_client.*]
 ignore_missing_imports = True
 
 # There is no type hinting for jsonpath_ng

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.4.1     unreleased
+
+	* Use InfluxDBClient.write_api(SYNCHRONOUS) so file handles are closed.
+
 Version 0.4.0     19 Jun 2022
 
 	* Rename GitHub repo to smartapp-sensortrack.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sensortrack"
-version = "0.4.0"
+version = "0.4.1a1"
 description = "Historically track sensor data from SmartThings"
 authors = ["Kenneth J. Pronovici <pronovic@ieee.org>"]
 license = "Apache-2.0"

--- a/src/sensortrack/handler.py
+++ b/src/sensortrack/handler.py
@@ -9,6 +9,7 @@ import logging
 from typing import List, Optional, Union
 
 from influxdb_client import InfluxDBClient, Point
+from influxdb_client.client.write_api import SYNCHRONOUS
 from smartapp.interface import (
     ConfigurationRequest,
     ConfirmationRequest,
@@ -75,7 +76,7 @@ class EventHandler(SmartAppEventHandler):
             points = []  # type: List[Point]
             self._handle_weather_lookup_events(request, points)
             self._handle_sensor_events(request, points)
-            client.write_api().write(bucket=bucket, record=points)
+            client.write_api(write_options=SYNCHRONOUS).write(bucket=bucket, record=points)
             logging.debug("[%s] Completed persisting %d point(s) of data", correlation_id, len(points))
 
     def _handle_config_refresh(


### PR DESCRIPTION
After the service had been up a bit more than 24 hours, I ran into a large number of this errors in `/var/log/syslog`.  I actually filled up the relatively small `/var` directory and crashed the VM where the service was running.   

```
21 20:42:19 mercury sensortrack[3632639]: ERROR socket.accept() out of system resource
Jun 21 20:42:19 mercury sensortrack[3632639]: socket: <asyncio.TransportSocket fd=6, family=AddressFamily.AF_INET, type=SocketKind.>
Jun 21 20:42:19 mercury sensortrack[3632639]: Traceback (most recent call last):
Jun 21 20:42:19 mercury sensortrack[3632639]:   File "/usr/lib/python3.9/asyncio/selector_events.py", line 164, in _accept_connecti>
Jun 21 20:42:19 mercury sensortrack[3632639]:   File "/usr/lib/python3.9/socket.py", line 293, in accept
Jun 21 20:42:19 mercury sensortrack[3632639]: OSError: [Errno 24] Too many open files 
```

In further testing, I established that the count of open files reported by `lsof` was growing after every request, and this was driven by a growing number of connections to InfluxDB that were sitting in the `CLOSE_WAIT` state.  I reviewed the documentation for the InfluxDB  client, and realized that I was using the wait writer incorrectly - it either needs to be marked as `SYNCHRONOUS` or used in a `with` statement.  I moved it to synchronous operation, and that seems to have eliminated the problem with `CLOSE_WAIT` connections.

