### PR TITLE
Handle weather.gov errors with a simple logged error message

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.4.4     unreleased
+
+	* Handle weather.gov errors with a simple logged error message.
+
 Version 0.4.3     05 Sep 2022
 
 	* Upgrade to Poetry v1.2.0 and make related build process changes.


### PR DESCRIPTION
The weather.gov service is generally reliable, but it does fail occasionally.  When it does, the logged message is a HUGE stack trace, because of all the retries.   This is way more information that we need.  This PR adjusts the code to just log a simple error message instead.

------

```
Read timed out. (read timeout=5.0)", '0156223a-cfd6-49d1-b8e8-cbc0743adc4b')
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 382, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 1012, in _validate_conn
    conn.connect()
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 411, in connect
    self.sock = ssl_wrap_socket(
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 449, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(
  File "/usr/lib/python3/dist-packages/urllib3/util/ssl_.py", line 493, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/lib/python3.9/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.9/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/lib/python3.9/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
The handshake operation timed out
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/sensortrack/.local/lib/python3.9/site-packages/requests/adapters.py", line 489, in send
    resp = conn.urlopen(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 755, in urlopen
    retries = retries.increment(
  File "/usr/lib/python3/dist-packages/urllib3/util/retry.py", line 532, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/usr/lib/python3/dist-packages/six.py", line 719, in reraise
    raise value
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 385, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=conn.timeout)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 336, in _raise_timeout
    raise ReadTimeoutError(
Read timed out. (read timeout=5.0)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/sensortrack/.local/lib/python3.9/site-packages/smartapp/dispatcher.py", line 124, in dispatch
    response = self._handle_request(context.correlation_id, request)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/smartapp/dispatcher.py", line 156, in _handle_request
    self.event_handler.handle_event(correlation_id, request)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/sensortrack/handler.py", line 81, in handle_event
    self._handle_weather_lookup_events(request, points)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/sensortrack/handler.py", line 106, in _handle_weather_lookup_events
    temperature, humidity = retrieve_current_conditions(location.latitude, location.longitude)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/sensortrack/weather.py", line 87, in retrieve_current_conditions
    return _retrieve_latest_observation(station_url)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/tenacity/__init__.py", line 324, in wrapped_f
    return self(f, *args, **kw)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/tenacity/__init__.py", line 404, in __call__
    do = self.iter(retry_state=retry_state)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/tenacity/__init__.py", line 349, in iter
    return fut.result()
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 433, in result
    return self.__get_result()
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/home/sensortrack/.local/lib/python3.9/site-packages/tenacity/__init__.py", line 407, in __call__
    result = fn(*args, **kwargs)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/sensortrack/weather.py", line 77, in _retrieve_latest_observation
    response = requests.get(url=url, timeout=_CLIENT_TIMEOUT_SEC)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/requests/adapters.py", line 578, in send
    raise ReadTimeout(e, request=request)
Read timed out. (read timeout=5.0)
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/sensortrack/.local/lib/python3.9/site-packages/sensortrack/server.py", line 39, in _generic_error_handler
    raise e
  File "/home/sensortrack/.local/lib/python3.9/site-packages/starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/sensortrack/.local/lib/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/starlette/routing.py", line 266, in handle
    await self.app(scope, receive, send)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/starlette/routing.py", line 65, in app
    response = await func(request)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/fastapi/routing.py", line 227, in app
    raw_response = await run_endpoint_function(
  File "/home/sensortrack/.local/lib/python3.9/site-packages/fastapi/routing.py", line 160, in run_endpoint_function
    return await dependant.call(**values)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/sensortrack/server.py", line 105, in smartapp
    content = dispatcher().dispatch(context=context)
  File "/home/sensortrack/.local/lib/python3.9/site-packages/smartapp/dispatcher.py", line 133, in dispatch
    raise InternalError("%s" % e, context.correlation_id) from e
Read timed out. (read timeout=5.0)", '0156223a-cfd6-49d1-b8e8-cbc0743adc4b')
```