### PR TITLE
Rewrite tests to use the responses framework

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.4.9     unreleased
+
+	* Rewrite request-related tests to use the responses framework.
+
 Version 0.4.8     26 Feb 2023
 
 	* Upgrade all dependencies to the latest major version.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1145,13 +1145,6 @@ files = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -1216,6 +1209,27 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "responses"
+version = "0.22.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "responses-0.22.0-py3-none-any.whl", hash = "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"},
+    {file = "responses-0.22.0.tar.gz", hash = "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e"},
+]
+
+[package.dependencies]
+requests = ">=2.22.0,<3.0"
+toml = "*"
+types-toml = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
 
 [[package]]
 name = "rfc3986"
@@ -1425,6 +1439,18 @@ files = [
 types-urllib3 = "<1.27"
 
 [[package]]
+name = "types-toml"
+version = "0.10.8.5"
+description = "Typing stubs for toml"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-toml-0.10.8.5.tar.gz", hash = "sha256:bf80fce7d2d74be91148f47b88d9ae5adeb1024abef22aa2fdbabc036d6b8b3c"},
+    {file = "types_toml-0.10.8.5-py3-none-any.whl", hash = "sha256:2432017febe43174af0f3c65f03116e3d3cf43e7e1406b8200e106da8cf98992"},
+]
+
+[[package]]
 name = "types-urllib3"
 version = "1.26.25.8"
 description = "Typing stubs for urllib3"
@@ -1598,4 +1624,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "830c2a02362188c22f3fe3e8dc87893ff0ca5d349e3d7db303f542ffbbd868a5"
+content-hash = "6b6fdb798be1d3e2e0359ea075a95e4359a161e305711eb45ce25bafdcf98943"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ types-requests = "^2.28.11.15"
 types-Jinja2 = "^2.11.9"
 colorama = "~0, >=0.4.6"
 httpx = "~0, >=0.23.3"
+responses = "~0, >=0.22.0"
 
 [tool.black]
 line-length = 132

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,60 +1,51 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
-import json
 import os
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from requests import HTTPError
+import responses
+from responses import matchers
+from responses.registries import OrderedRegistry
 
 from sensortrack.weather import retrieve_current_conditions
 from tests.testutil import load_file
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+TIMEOUT_MATCHER = matchers.request_kwargs_matcher({"timeout": 5.0})
 
 
 class TestPublicFunctions:
-    @patch("sensortrack.weather.raise_for_status")
-    @patch("sensortrack.weather.requests")
     @patch("sensortrack.weather.config")
-    def test_retrieve_current_conditions(self, config, requests, raise_for_status):
+    def test_retrieve_current_conditions(self, config):
         config.return_value = MagicMock(weather=MagicMock(base_url="https://base"))
+        with responses.RequestsMock(registry=OrderedRegistry) as r:
+            r.get(
+                url="https://base/points/12.3,45.6/stations",
+                status=500,
+                match=[TIMEOUT_MATCHER],
+            )
+            r.get(
+                url="https://base/points/12.3,45.6/stations",
+                status=200,
+                body=load_file(os.path.join(FIXTURE_DIR, "weather", "stations.json")),
+                match=[TIMEOUT_MATCHER],
+            )
+            r.get(
+                url="https://api.weather.gov/stations/KALO/observations/latest",  # first station from JSON, which is closest
+                status=500,
+                match=[TIMEOUT_MATCHER],
+            )
+            r.get(
+                url="https://api.weather.gov/stations/KALO/observations/latest",  # first station from JSON, which is closest
+                status=200,
+                body=load_file(os.path.join(FIXTURE_DIR, "weather", "observations", "valid.json")),
+                match=[TIMEOUT_MATCHER],
+            )
+            # expected temperature taken from Google, to sanity-check library
+            assert retrieve_current_conditions(latitude=12.3, longitude=45.6) == (84.92, 41.59)
+            assert len(r.calls) == 4  # one retry and one success for each endpoint
 
-        exception = HTTPError("hello")
-
-        stations = load_file(os.path.join(FIXTURE_DIR, "weather", "stations.json"))
-        stations_url = "https://base/points/12.3,45.6/stations"
-        stations_response = MagicMock(json=MagicMock(return_value=json.loads(stations)))
-
-        observations = load_file(os.path.join(FIXTURE_DIR, "weather", "observations", "valid.json"))
-        observations_url = "https://api.weather.gov/stations/KALO/observations/latest"  # first station from JSON, which is closest
-        observations_response = MagicMock(json=MagicMock(return_value=json.loads(observations)))
-
-        # each exception is thrown, and that is handled by the retry annotation
-        requests.get = MagicMock(
-            side_effect=[exception, stations_response, exception, observations_response, observations_response]
-        )
-
-        # expected temperature taken from Google, to sanity-check library
-        assert retrieve_current_conditions(latitude=12.3, longitude=45.6) == (84.92, 41.59)
-
-        requests.get.assert_has_calls(
-            [
-                call(url=stations_url, timeout=5.0),
-                call(url=stations_url, timeout=5.0),
-                call(url=observations_url, timeout=5.0),
-                call(url=observations_url, timeout=5.0),
-            ]
-        )
-        raise_for_status.assert_has_calls(
-            [
-                call(stations_response),
-                call(observations_response),
-            ]
-        )
-
-    @patch("sensortrack.weather.raise_for_status")
-    @patch("sensortrack.weather.requests")
     @patch("sensortrack.weather.config")
     @pytest.mark.parametrize(
         "input_file,expected",
@@ -64,31 +55,20 @@ class TestPublicFunctions:
             ("null.json", (None, None)),
         ],
     )
-    def test_retrieve_current_conditions_bad_data(self, config, requests, raise_for_status, input_file, expected):
+    def test_retrieve_current_conditions_bad_data(self, config, input_file, expected):
         config.return_value = MagicMock(weather=MagicMock(base_url="https://base"))
-
-        stations = load_file(os.path.join(FIXTURE_DIR, "weather", "stations.json"))
-        stations_url = "https://base/points/12.3,45.6/stations"
-        stations_response = MagicMock(json=MagicMock(return_value=json.loads(stations)))
-
-        observations = load_file(os.path.join(FIXTURE_DIR, "weather", "observations", input_file))
-        observations_url = "https://api.weather.gov/stations/KALO/observations/latest"  # first station from JSON, which is closest
-        observations_response = MagicMock(json=MagicMock(return_value=json.loads(observations)))
-
-        requests.get = MagicMock(side_effect=[stations_response, observations_response])
-
-        # expected temperature taken from Google, to sanity-check library
-        assert retrieve_current_conditions(latitude=12.3, longitude=45.6) == expected
-
-        requests.get.assert_has_calls(
-            [
-                call(url=stations_url, timeout=5.0),
-                call(url=observations_url, timeout=5.0),
-            ]
-        )
-        raise_for_status.assert_has_calls(
-            [
-                call(stations_response),
-                call(observations_response),
-            ]
-        )
+        with responses.RequestsMock(registry=OrderedRegistry) as r:
+            r.get(
+                url="https://base/points/12.3,45.6/stations",
+                status=200,
+                body=load_file(os.path.join(FIXTURE_DIR, "weather", "stations.json")),
+                match=[TIMEOUT_MATCHER],
+            )
+            r.get(
+                url="https://api.weather.gov/stations/KALO/observations/latest",  # first station from JSON, which is closest
+                status=200,
+                body=load_file(os.path.join(FIXTURE_DIR, "weather", "observations", input_file)),
+                match=[TIMEOUT_MATCHER],
+            )
+            # expected temperature taken from Google, to sanity-check library
+            assert retrieve_current_conditions(latitude=12.3, longitude=45.6) == expected


### PR DESCRIPTION
The unit tests for web client code (that rely on mocking the requests framework) have historically been pretty awkward.  It takes a bunch of code to set up the responses and check the correct behavior.  It turns out that frameworks have been written to simplify this.  Two of these are [responses](https://pypi.org/project/responses/) and [requests-mock](https://pypi.org/project/requests-mock/).  I experimented with both, and found that I preferred responses, so I have rewritten all of the tests to use it.  The framework lets you stub out responses from the server (much like wiremock for Java) and also automatically fails a test if an expected stub isn't invoked.  I think that the tests are more legible now, and they should be easier to maintain.