### PR TITLE
Remove deprecated FastAPI startup/shutdown hooks (not needed)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ Version 0.4.13     unreleased
 
 	* Update urllib3 to address Dependabot warnings.
 	* Upgrade to Poetry v1.7.0 for official Python 3.12 support.
+	* Remove deprecated (and unused) FastAPI lifecycle event handlers.
 
 Version 0.4.12     15 Oct 2023
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1615,13 +1615,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.23.2"
+version = "0.24.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "uvicorn-0.23.2-py3-none-any.whl", hash = "sha256:1f9be6558f01239d4fdf22ef8126c39cb1ad0addf76c40e760549d2c2f43ab53"},
-    {file = "uvicorn-0.23.2.tar.gz", hash = "sha256:4d3cc12d7727ba72b64d12d3cc7743124074c0a69f7b201512fc50c3e3f1569a"},
+    {file = "uvicorn-0.24.0-py3-none-any.whl", hash = "sha256:3d19f13dfd2c2af1bfe34dd0f7155118ce689425fdf931177abe832ca44b8a04"},
+    {file = "uvicorn-0.24.0.tar.gz", hash = "sha256:368d5d81520a51be96431845169c225d771c9dd22a58613e1a181e6c4512ac33"},
 ]
 
 [package.dependencies]

--- a/src/sensortrack/server.py
+++ b/src/sensortrack/server.py
@@ -72,18 +72,6 @@ async def exception_handler(_: Request, e: Exception) -> Response:
     return _generic_error_handler(e, 500, "Internal error: %s" % e)
 
 
-@API.on_event("startup")
-async def startup_event() -> None:
-    """Do setup at server startup."""
-    logging.info("Server startup complete")
-
-
-@API.on_event("shutdown")
-async def shutdown_event() -> None:
-    """Do cleanup at server shutdown."""
-    logging.info("Server shutdown complete")
-
-
 @API.get("/health")
 async def health() -> Health:
     """Return an API health indicator."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,10 +16,8 @@ from sensortrack.server import (
     exception_handler,
     influxdb_error_handler,
     rest_client_error_handler,
-    shutdown_event,
     signature_error_handler,
     smartapp_error_handler,
-    startup_event,
 )
 
 CLIENT = TestClient(API)
@@ -57,16 +55,6 @@ class TestErrorHandlers:
         e = Exception("hello")
         response = await exception_handler(None, e)
         assert response.status_code == 500
-
-
-class TestLifecycle:
-    pytestmark = pytest.mark.asyncio
-
-    async def test_startup_event(self):
-        await startup_event()  # just make sure it runs
-
-    async def test_shutdown_event(self):
-        await shutdown_event()  # just make sure it runs
 
 
 class TestRoutes:


### PR DESCRIPTION
The latest version of FastAPI deprecates some of the lifecycle handlers in favor of a new mechanism.  The only reason we're using those lifecycle handlers at all is to log some startup/shutdown messages, but FastAPI already logs similar messages.  So, we can just remove the handlers.